### PR TITLE
Messaging that external developers should use integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The uploader tool will ask for any information necessary to upload the zip file.
 To skip any of the questions the uploader would typically ask, you can pass the respective information as command line arguments. An example is as follows:
 
 ```
-npx @adobe/reactor-uploader package-myextension-1.0.0.zip --environment=production --private-key=/Users/jane/launchkeys/reactor_integration_private.key --org-id=01C20D883A7D42080A494212@AdobeOrg --tech-account-id=14A533A72B181CF90A44410D@techacct.adobe.com --api-key=192ce541b1144160941a83vb74e0e74d --client-secret=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+npx @adobe/reactor-uploader package-myextension-1.0.0.zip --environment=integration --private-key=/Users/jane/launchkeys/reactor_integration_private.key --org-id=01C20D883A7D42080A494212@AdobeOrg --tech-account-id=14A533A72B181CF90A44410D@techacct.adobe.com --api-key=192ce541b1144160941a83vb74e0e74d --client-secret=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 The first positional parameter is the path (relative or absolute) to the zip file you wish to upload. In the example, `package-myextension-1.0.0.zip` is passed as an argument for this parameter.
@@ -53,7 +53,7 @@ The named parameters are as follows:
 
 ##### --environment
 
-The environment to which the extension package should be uploaded. Valid options are `development`, `qe`, `integration`, and `production`. Users outside of Adobe will only use `production`.
+The environment to which the extension package should be uploaded. Valid options are `development`, `qe`, `integration`, and `production`. Users outside of Adobe will only use `integration`.
 
 ##### --private-key (for authentication using an Adobe I/O integration)
 

--- a/bin/getEnvironment.js
+++ b/bin/getEnvironment.js
@@ -31,11 +31,11 @@ module.exports = async (argv) => {
             value: 'qe'
           },
           {
-            name: 'Integration (Adobe Internal Use Only)',
+            name: 'Integration',
             value: 'integration'
           },
           {
-            name: 'Production',
+            name: 'Production (Adobe Internal Use Only)',
             value: 'production'
           }
         ],


### PR DESCRIPTION
I was mistaken in thinking that external devs should be using production. Apparently they're supposed to be using integration still.