### PR TITLE
Improved error formatting.

### DIFF
--- a/bin/__tests__/handleResponseError.test.js
+++ b/bin/__tests__/handleResponseError.test.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  ****************************************************************************************/
 
-let handleResponseError = require('../handleResponseError');
+const os = require('os');
+const chalk = require('chalk');
+const handleResponseError = require('../handleResponseError');
 
 describe('handleResponseError', () => {
   it('throws an error for Adobe I/O error response', () => {
@@ -47,7 +49,8 @@ describe('handleResponseError', () => {
       errorMessage = error.message;
     }
 
-    expect(errorMessage).toBe('Failed to do something. Disk Error. Out of disk space.');
+    expect(errorMessage).toBe(`Failed to do something. ` +
+      `${os.EOL}${chalk.green('title: ')} Disk Error.${os.EOL}${chalk.green('detail: ')}Out of disk space.`);
   });
 
   it('throws an error for unknown type of error response', () => {

--- a/bin/__tests__/monitorStatus.test.js
+++ b/bin/__tests__/monitorStatus.test.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  ****************************************************************************************/
 
+const os = require('os');
+const chalk = require('chalk');
 const proxyquire = require('proxyquire');
 const getReactorHeaders = require('../getReactorHeaders');
 
@@ -114,6 +116,8 @@ describe('monitorStatus', () => {
     expect(mockRequest).toHaveBeenCalledWith(expectedRequestOptions);
     expect(spinner.start).toHaveBeenCalled();
     expect(spinner.stop).toHaveBeenCalled();
-    expect(errorMessage).toBe('Extension package processing failed. Bad Thing Happened. Something really bad happened.');
+    expect(errorMessage).toBe(`Extension package processing failed. ` +
+      `${os.EOL}${chalk.green('title: ')} Bad Thing Happened.${os.EOL}` +
+      `${chalk.green('detail: ')}Something really bad happened.`);
   });
 });

--- a/bin/getMessageFromReactorError.js
+++ b/bin/getMessageFromReactorError.js
@@ -10,6 +10,9 @@
  * governing permissions and limitations under the License.
  ****************************************************************************************/
 
+const os = require('os');
+const prettyjson = require('prettyjson');
+
 module.exports = (error) => {
-  return `${error.title}${error.detail ? ' ' + error.detail : ''}`;
+  return os.EOL + prettyjson.render(error);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -435,6 +435,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colors": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+    },
     "combined-stream": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
@@ -2141,8 +2146,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -2471,6 +2475,15 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
+    },
+    "prettyjson": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "requires": {
+        "colors": "^1.1.2",
+        "minimist": "^1.2.0"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "inquirer": "^5.2.0",
     "jwt-simple": "^0.5.1",
     "ora": "^2.1.0",
+    "prettyjson": "^1.2.1",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5",
     "yargs": "^11.0.0",


### PR DESCRIPTION
Concatenating the title and detail like we were makes for some odd results like this:

`Extension package processing failed. Invalid name name is unavailable`

I decided to just show the whole error object that we get back from the server. It ends up looking like this:

![image](https://user-images.githubusercontent.com/210820/47240221-eed78880-d3a4-11e8-999a-ca650ef9caf5.png)
