### PR TITLE
DTM-13285 Show native JS errors details.

### DIFF
--- a/bin/__tests__/getIntegrationAccessToken.test.js
+++ b/bin/__tests__/getIntegrationAccessToken.test.js
@@ -241,7 +241,6 @@ describe('getIntegrationAccessToken', () => {
       // we bailed after the first call because it wasn't a scoping error
       expect(mockAuth.calls.count()).toBe(1)
 
-      // This tests that if all metascopes fail, the error from the last attempt is ultimately thrown.
       expect(errorMessage).toBe(
         `Error retrieving access token. ${mockedAuthError}`
       );

--- a/bin/getIntegrationAccessToken.js
+++ b/bin/getIntegrationAccessToken.js
@@ -109,9 +109,14 @@ module.exports = async (
 
       return response.access_token;
     } catch (e) {
-      if (e.error !== 'invalid_scope' || i === METASCOPES.length - 1) {
+      const { message: errorMessage = '' } = e;
+      const isScopeError = errorMessage.toLowerCase().indexOf('invalid_scope') !== -1;
+      const hasCheckedFinalScope = i === METASCOPES.length - 1;
+
+      // throw immediately if we've encountered any error that isn't a scope error
+      if (!isScopeError || hasCheckedFinalScope) {
         throw new Error(
-          `Error retrieving access token. ${e.error_description || e}`
+          `Error retrieving access token. ${errorMessage}`
         );
       }
     }

--- a/bin/getIntegrationAccessToken.js
+++ b/bin/getIntegrationAccessToken.js
@@ -109,7 +109,7 @@ module.exports = async (
 
       return response.access_token;
     } catch (e) {
-      const { message: errorMessage = '' } = e;
+      const { message: errorMessage = 'An unknown authentication error occurred.' } = e;
       const isScopeError = errorMessage.toLowerCase().indexOf('invalid_scope') !== -1;
       const hasCheckedFinalScope = i === METASCOPES.length - 1;
 

--- a/bin/getIntegrationAccessToken.js
+++ b/bin/getIntegrationAccessToken.js
@@ -111,7 +111,7 @@ module.exports = async (
     } catch (e) {
       if (e.error !== 'invalid_scope' || i === METASCOPES.length - 1) {
         throw new Error(
-          `Error retrieving access token. ${e.error_description}`
+          `Error retrieving access token. ${e.error_description || e}`
         );
       }
     }


### PR DESCRIPTION
`jwt-auth` throws native errors or objects containing the `error_description` property for errors thrown by the API. We need to capture both types.