### PR TITLE
Use @adobe/jwt-auth 0.3.0 or greater

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,25 +5,13 @@
   "requires": true,
   "dependencies": {
     "@adobe/jwt-auth": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/jwt-auth/-/jwt-auth-0.1.0.tgz",
-      "integrity": "sha512-/MCI16+HhGHcrPcs7JpomatgC/YTnI4qQYYX/GH3SV+l1a/j1BpHyuwb/K+s1knE28TYdKAX9pDcQmheZCxG1w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/jwt-auth/-/jwt-auth-0.3.0.tgz",
+      "integrity": "sha512-2MQ7Ld507WEaooqI0rkL00gVtBLdS4aijCAGKGarK9RmqzVCQ/5ogODdA8cFWpqwIMgKoLeXo3XtTUjuD5Q31Q==",
       "requires": {
         "form-data": "^2.3.3",
         "jsonwebtoken": "^8.4.0",
         "node-fetch": "^2.3.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "abbrev": {
@@ -2062,14 +2050,14 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -2377,9 +2365,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "nodemon": {
       "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:watch": "nodemon --exec jasmine JASMINE_CONFIG_PATH=jasmine.json"
   },
   "dependencies": {
-    "@adobe/jwt-auth": "^0.1.0",
+    "@adobe/jwt-auth": "^0.3.0",
     "chalk": "^2.4.2",
     "delay": "^4.2.0",
     "inquirer": "^6.3.1",


### PR DESCRIPTION
## Description

I recently released @adobe/jwt-auth 0.3.0 which expires the temporary JWT it creates after 5 minutes. This is a security improvement I hope everyone move to.

## Related Issue

https://github.com/adobe/jwt-auth/issues/23

## Motivation and Context

The JWT token was valid for 24 hours but since we create the bearer token shortly after creating the JWT and the JWT is never re-used it should expire quickly.

## How Has This Been Tested?

Generated an auth token, grabbed the JWT and tried to use it after 5 minutes elapsed time. It was rejected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
