### PR TITLE
Cleared confusion between API Key and Client ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Your technical account ID. You can find this on the overview screen for the inte
 
 ##### --api-key (for authentication using an Adobe I/O integration)
 
-Your API key. You can find this on the overview screen for the integration you have created within the [Adobe I/O console](https://console.adobe.io).
+Your API key/Client ID. You can find this on the overview screen for the integration you have created within the [Adobe I/O console](https://console.adobe.io).
 
 ##### --client-secret (for authentication using an Adobe I/O integration)
 

--- a/bin/getIntegrationAccessToken.js
+++ b/bin/getIntegrationAccessToken.js
@@ -67,7 +67,7 @@ module.exports = async (
       {
         type: 'input',
         name: 'apiKey',
-        message: 'What is your API key?',
+        message: 'What is your API key/Client ID?',
         validate: Boolean,
       },
     ]));

--- a/bin/index.js
+++ b/bin/index.js
@@ -30,7 +30,7 @@ const argv = require('yargs')
     },
     'api-key': {
       type: 'string',
-      describe: 'For authentication using an Adobe I/O integration. Your API key. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io).'
+      describe: 'For authentication using an Adobe I/O integration. Your API key/Client ID. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io).'
     },
     'client-secret': {
       type: 'string',


### PR DESCRIPTION
From https://github.com/adobe/reactor-uploader/issues/27

Updated README.md, index.js and getIntegrationAccessToken to clearly specifiy that API Key = Client ID.

What could be done to further improve: The JWT Library responses `invalid client_id parameter` which is then displayed by Line 116 at getIntegrationAccessToken. One possible way to remove the confusion could be checking explicitly for this error message and modifying it to something like `invalid api_key parameter`.  