### PR TITLE
DTM-13285 Add test and fix for fallback error message

### DIFF
--- a/bin/__tests__/getIntegrationAccessToken.test.js
+++ b/bin/__tests__/getIntegrationAccessToken.test.js
@@ -255,5 +255,32 @@ describe('getIntegrationAccessToken', () => {
         `Error retrieving access token. ${mockedAuthError}`
       );
     });
+
+    it('contains a fallback message for authentication errors', async () => {
+      // don't supply a message during auth failure
+      mockAuth.and.returnValue(Promise.reject(new Error()));
+
+      let errorMessage;
+      try {
+        await getIntegrationAccessToken(
+          {
+            scope: 'https://scope.com/s/'
+          },
+          {
+            privateKey: 'MyPrivateKey',
+            orgId: 'MyOrgId',
+            techAccountId: 'MyTechAccountId',
+            apiKey: 'MyApiKey',
+            clientSecret: 'MyClientSecret'
+          }
+        );
+      } catch (error) {
+        errorMessage = error.message;
+      }
+
+      expect(errorMessage).toBe(
+        'Error retrieving access token. An unknown authentication error occurred.'
+      );
+    });
   });
 });

--- a/bin/getIntegrationAccessToken.js
+++ b/bin/getIntegrationAccessToken.js
@@ -111,7 +111,7 @@ module.exports = async (
 
       return response.access_token;
     } catch (e) {
-      const { message: errorMessage = 'An unknown authentication error occurred.' } = e;
+      const errorMessage = e.message || 'An unknown authentication error occurred.';
       const isScopeError = errorMessage.toLowerCase().indexOf('invalid_scope') !== -1;
       const hasCheckedFinalScope = i === METASCOPES.length - 1;
 


### PR DESCRIPTION
Addresses a problem where `Error` objects with no message would still not display the fallback error.