### PR TITLE
Use the correct filter.

### DIFF
--- a/bin/__tests__/getExtensionPackageFromServer.test.js
+++ b/bin/__tests__/getExtensionPackageFromServer.test.js
@@ -35,7 +35,7 @@ describe('getExtensionPackageFromServer', () => {
       'page[number]': 1,
       'filter[name]': 'EQ fake-extension',
       'filter[platform]': 'EQ web',
-      'filter[status]': 'EQ succeeded, EQ failed'
+      'filter[status]': 'EQ succeeded,EQ failed'
     },
     headers: getReactorHeaders('fake-token'),
     transform: JSON.parse

--- a/bin/getExtensionPackageFromServer.js
+++ b/bin/getExtensionPackageFromServer.js
@@ -29,7 +29,7 @@ module.exports = async (
       'page[number]': 1,
       'filter[name]': `EQ ${extensionPackageManifest.name}`,
       'filter[platform]': `EQ ${extensionPackageManifest.platform}`,
-      'filter[status]': 'EQ succeeded, EQ failed'
+      'filter[status]': 'EQ succeeded,EQ failed'
     },
     headers: getReactorHeaders(accessToken),
     transform: JSON.parse


### PR DESCRIPTION
Seems that the space after the comma in `EQ succeeded, EQ failed` was not correct.