### PR TITLE
PDCL-5086: optional chaining is only available in node >= 14, which i…

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -66,7 +66,7 @@ const checkOldProductionEnvironmentVariables = require('./checkOldProductionEnvi
     if (argv.verbose) {
       require('request-debug')(require('request-promise-native'), function(type, data, r) {
         const filteredData = { ...data };
-        if (filteredData.headers?.Authorization) {
+        if (filteredData.headers && filteredData.headers.Authorization) {
           filteredData.headers.Authorization = 'Bearer [USER_ACCESS_TOKEN]'
         }
         console.error({ [type]: filteredData })
@@ -108,6 +108,7 @@ const checkOldProductionEnvironmentVariables = require('./checkOldProductionEnvi
     }
 
     console.log(chalk.bold.red(error.message));
+    console.log(chalk.bold.red('run in --verbose mode for more info'));
     process.exitCode = 1;
   }
 })();


### PR DESCRIPTION
…s higher than our recommendation

<!-- Copyright 2020 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

During development of #43 , the optional chaining syntax was introduced to solve the problem. Optional chaining is only available in node >= 14, however, we recommend that users can use node 12.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-5086

## Motivation and Context

Bug fix to allow users on older node versions to use uploader

## How Has This Been Tested?

1. `npm test`
2. manual verification that uploading can happen using node 12

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
