### PR TITLE
Stringify all property of errors

### DIFF
--- a/bin/__tests__/handleResponseError.test.js
+++ b/bin/__tests__/handleResponseError.test.js
@@ -65,4 +65,17 @@ describe('handleResponseError', () => {
 
     expect(errorMessage).toBe(`Failed to do something. An unknown error occurred: ${JSON.stringify(error)}.`);
   });
+
+  it('throws an error for unknown type of error response', () => {
+    let errorMessage;
+    const error = new Error('unexpected');
+
+    try {
+      handleResponseError(error, 'Failed to do something.');
+    } catch (error) {
+      errorMessage = error.message;
+    }
+
+    expect(errorMessage).toBe(`Failed to do something. An unknown error occurred: ${JSON.stringify(error, Object.getOwnPropertyNames(error))}.`);
+  });
 });

--- a/bin/handleResponseError.js
+++ b/bin/handleResponseError.js
@@ -21,7 +21,7 @@ module.exports = (error, messagePrefix) => {
     message = getMessageFromReactorError(error.response.errors[0]);
   } else {
     let errorString;
-    try { errorString = JSON.stringify(error); }
+    try { errorString = JSON.stringify(error, Object.getOwnPropertyNames(error)); }
     catch (e) {}
     message = `An unknown error occurred${errorString ? `: ${errorString}` : ''}.`;
   }


### PR DESCRIPTION
## Description

Change how errors objects are stringified. Use all properties, not only enumerable ones.

## Related Issue

#53

## Motivation and Context

Stringify to JSON will omit non enumerable properties by default.

That the case when you try to stringify errors: 

```js
JSON.stringify(new Error("message", {cause: new Error("message 2")})) === "{}";
```

Example of the current output when upload a package when a more recent package was already uploaded:

```
$ npx @adobe/reactor-uploader "$PACKAGE_PATH" --org-id="$ORGANIZATION_ID" --private-key="$PRIVATE_KEY" --tech-account-id="$TECHNICAL_ACCOUNT_ID" --api-key="$API_KEY" --client-secret="$CLIENT_SECRET"
No development extension package was found on the server with the name [REDACTED]. A new extension package will be created.
--verbose output:
[REDACTED]/node_modules/@adobe/reactor-uploader/bin/handleResponseError.js:29
  throw new Error(messagePrefix + ' ' + message);
        ^
Error: Error uploading extension package. An unknown error occurred: {}.
    at module.exports ([REDACTED]/node_modules/@adobe/reactor-uploader/bin/handleResponseError.js:29:9)
    at module.exports ([REDACTED]/node_modules/@adobe/reactor-uploader/bin/uploadZip.js:71:5)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async [REDACTED]/node_modules/@adobe/reactor-uploader/bin/index.js:82:32
```

## How Has This Been Tested?

With `npm test` in [codespace](https://github.com/features/codespaces)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
