### PR TITLE
Deprecate QE endpoint, nuke Integration endpoint.

### DIFF
--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   notify-on-success:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.tag == 'latest' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - name: Get latest tag

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The environment to which the extension package should be uploaded. Valid options
 Private key path can also be provided by setting an environment variable. The environment variable should be named one of the following, depending on which Experience Platform Tags environment will be receiving the extension package:
 
 * `REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT`
+* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE`
 * `REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE`
-* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_INTEGRATION`
 
 Client secret can also be provided by setting an environment variable. The environment variable should be named one of the following, depending on which Experience Platform Tags environment will be receiving the extension package:
 
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT`
+* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE`
-* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_INTEGRATION`
 
 ##### --verbose
 

--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Private key path can also be provided by setting an environment variable. The en
 
 * `REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT`
 * `REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE`
-* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE`
+* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE` (Deprecated. Please favor `REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE`)
 
 Client secret can also be provided by setting an environment variable. The environment variable should be named one of the following, depending on which Experience Platform Tags environment will be receiving the extension package:
 
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT`
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`
-* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE`
+* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE` (Deprecated. Please favor `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`)
 
 ##### --verbose
 

--- a/bin/envConfig.json
+++ b/bin/envConfig.json
@@ -9,16 +9,16 @@
   "qe": {
     "ims": "https://ims-na1-stg1.adobelogin.com",
     "scope": "https://ims-na1-stg1.adobelogin.com/s/",
-    "extensionPackages": "https://reactor-qe.adobe.io/extension_packages",
+    "extensionPackages": "https://reactor-stage.adobe.io/extension_packages",
     "privateKeyEnvVar": "REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE",
     "clientSecretEnvVar": "REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE"
   },
-  "integration": {
-    "ims": "https://ims-na1.adobelogin.com",
-    "scope": "https://ims-na1.adobelogin.com/s/",
-    "extensionPackages": "https://reactor-integration.adobe.io/extension_packages",
-    "privateKeyEnvVar": "REACTOR_IO_INTEGRATION_PRIVATE_KEY_INTEGRATION",
-    "clientSecretEnvVar": "REACTOR_IO_INTEGRATION_CLIENT_SECRET_INTEGRATION"
+  "stage": {
+    "ims": "https://ims-na1-stg1.adobelogin.com",
+    "scope": "https://ims-na1-stg1.adobelogin.com/s/",
+    "extensionPackages": "https://reactor-stage.adobe.io/extension_packages",
+    "privateKeyEnvVar": "REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE",
+    "clientSecretEnvVar": "REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE"
   },
   "production": {
     "ims": "https://ims-na1.adobelogin.com",

--- a/bin/index.js
+++ b/bin/index.js
@@ -20,7 +20,7 @@ const argv = require('yargs/yargs')(hideBin(process.argv))
   .options({
     'private-key': {
       type: 'string',
-      describe: 'For authentication using an Adobe I/O integration. The local path (relative or absolute) to the RSA private key. Instructions on how to generate this key can be found in the Getting Started guide (https://developer.adobelaunch.com/guides/extensions/getting-started/) and should have been used when creating your integration through the Adobe I/O console. Optionally, rather than passing the private key path as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT, REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE, REACTOR_IO_INTEGRATION_PRIVATE_KEY_INTEGRATION, REACTOR_IO_INTEGRATION_PRIVATE_KEY'
+      describe: 'For authentication using an Adobe I/O integration. The local path (relative or absolute) to the RSA private key. Instructions on how to generate this key can be found in the Getting Started guide (https://developer.adobelaunch.com/guides/extensions/getting-started/) and should have been used when creating your integration through the Adobe I/O console. Optionally, rather than passing the private key path as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT, REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE, REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE, REACTOR_IO_INTEGRATION_PRIVATE_KEY. REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE is deprecated in favor of REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE and will be removed in the future.'
     },
     'org-id': {
       type: 'string',
@@ -36,12 +36,12 @@ const argv = require('yargs/yargs')(hideBin(process.argv))
     },
     'client-secret': {
       type: 'string',
-      describe: 'For authentication using an Adobe I/O integration. Your client secret. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io). Optionally, rather than passing the client secret as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT, REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE, REACTOR_IO_INTEGRATION_CLIENT_SECRET_INTEGRATION, REACTOR_IO_INTEGRATION_CLIENT_SECRET'
+      describe: 'For authentication using an Adobe I/O integration. Your client secret. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io). Optionally, rather than passing the client secret as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT, REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE, REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE, REACTOR_IO_INTEGRATION_CLIENT_SECRET. REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE is deprecated in favor of REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE and will be removed in the future.'
     },
     environment: {
       type: 'string',
       describe: 'The environment to which the extension packaqe should be uploaded (for Adobe internal use only).',
-      choices: ['development', 'qe', 'integration']
+      choices: ['development', 'stage', 'qe']
     },
     verbose: {
       type: 'boolean',
@@ -69,6 +69,10 @@ const checkOldProductionEnvironmentVariables = require('./checkOldProductionEnvi
     const envSpecificConfig = envConfig[environment];
 
     checkOldProductionEnvironmentVariables();
+    if (environment === 'qe') {
+      console.log(chalk.bold.red('\'--environment=qe\' is currently redirecting to \'--environment=stage\' on your behalf, and will be removed in the future. Prefer usage of \'--environment=stage\'.'))
+      console.log(chalk.bold.red('Prefer usage of \'--environment=stage\'.'))
+    }
 
     const integrationAccessToken = await getIntegrationAccessToken(envSpecificConfig, argv);
     const zipPath = await getZipPath(argv);

--- a/bin/index.js
+++ b/bin/index.js
@@ -70,8 +70,8 @@ const checkOldProductionEnvironmentVariables = require('./checkOldProductionEnvi
 
     checkOldProductionEnvironmentVariables();
     if (environment === 'qe') {
-      console.log(chalk.bold.red('\'--environment=qe\' is currently redirecting to \'--environment=stage\' on your behalf, and will be removed in the future. Prefer usage of \'--environment=stage\'.'))
-      console.log(chalk.bold.red('Prefer usage of \'--environment=stage\'.'))
+      console.log(chalk.bold.red("'--environment=qe' is currently redirecting to '--environment=stage' on your behalf, and will be removed in the future."))
+      console.log(chalk.bold.red("Prefer usage of '--environment=stage'."))
     }
 
     const integrationAccessToken = await getIntegrationAccessToken(envSpecificConfig, argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-uploader",
-  "version": "5.0.10",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-uploader",
-  "version": "5.0.10",
+  "version": "5.1.0-beta.0",
   "description": "Command line tool for uploading Tags extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-uploader",
-  "version": "5.1.0-beta.0",
+  "version": "5.1.0-beta.1",
   "description": "Command line tool for uploading Tags extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-uploader",
-  "version": "5.1.0-beta.1",
+  "version": "5.1.0",
   "description": "Command line tool for uploading Tags extensions.",
   "author": {
     "name": "Adobe Systems",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Deprecates the usage of the {{environment=qe}} flag in favor of using {{environment=stage}}.
- Nukes the {{environment=integration}} option

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-10124

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Reactor Environment Restructure Jira Epic

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added a new test where the inquirer isn't mocked but we pass in the override flag

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.