### PR TITLE
Shortcut to include an access-token in a file

### DIFF
--- a/bin/__tests__/getIntegrationAccessToken.test.js
+++ b/bin/__tests__/getIntegrationAccessToken.test.js
@@ -68,7 +68,13 @@ describe('getIntegrationAccessToken', () => {
       prompt: jasmine.createSpy(),
     };
     mockFs = {
-      readFileSync: () => 'privateKey',
+      readFileSync: (path) => {
+        if (path === 'pathToAccessToken') {
+          return 'accessToken';          
+        } else {
+          return 'privateKey';
+        }
+      }
     };
     mockAuth = jasmine.createSpy().and.returnValue({
       access_token: 'generatedAccessToken',
@@ -145,6 +151,18 @@ describe('getIntegrationAccessToken', () => {
 
       expect(mockAuth).toHaveBeenCalledWith(expectedAuthOptions());
       expect(accessToken).toBe('generatedAccessToken');
+    });
+
+    it('supports access-token argument', async () => {
+      const accessToken = await getIntegrationAccessToken(
+        getEnvConfig(),
+        {
+          ...getArguments(),
+          accessToken: "pathToAccessToken"
+        }
+      );
+
+      expect(accessToken).toBe('accessToken');
     });
 
     it('uses environment variables if respective arguments do not exist', async () => {

--- a/bin/getIntegrationAccessToken.js
+++ b/bin/getIntegrationAccessToken.js
@@ -24,10 +24,14 @@ const METASCOPES = [
 
 module.exports = async (
   envConfig,
-  { privateKey, orgId, techAccountId, apiKey, clientSecret, verbose }
+  { privateKey, orgId, techAccountId, apiKey, clientSecret, verbose, accessToken }
 ) => {
   privateKey = privateKey || process.env[envConfig.privateKeyEnvVar];
   clientSecret = clientSecret || process.env[envConfig.clientSecretEnvVar];
+
+  if (accessToken) {
+    return fs.readFileSync(accessToken);
+  }
 
   if (!privateKey) {
     ({ privateKey } = await inquirer.prompt([

--- a/bin/index.js
+++ b/bin/index.js
@@ -18,6 +18,10 @@ const argv = require('yargs/yargs')(hideBin(process.argv))
   .usage('Usage: $0 <zipPath> [options]')
   .command('zipPath', 'The local path to the extension package zip file you wish to upload.')
   .options({
+    'access-token': {
+      type: 'string',
+      describe: 'For authentication using an Adobe I/O integration. The local path (relative or absolute) to a file holding the Access Token which can be generated in your integration through the Adobe I/O console.'
+    },
     'private-key': {
       type: 'string',
       describe: 'For authentication using an Adobe I/O integration. The local path (relative or absolute) to the RSA private key. Instructions on how to generate this key can be found in the Getting Started guide (https://developer.adobelaunch.com/guides/extensions/getting-started/) and should have been used when creating your integration through the Adobe I/O console. Optionally, rather than passing the private key path as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT, REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE, REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE, REACTOR_IO_INTEGRATION_PRIVATE_KEY. REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE is deprecated in favor of REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE and will be removed in the future.'


### PR DESCRIPTION
<!-- Copyright 2020 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

## Description

Access Token can be stored in a file and used when authenticating.

## Related Issue

Maybe:
#63 

## Motivation and Context

I had problems uploading an extension.

## How Has This Been Tested?

I included tests.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
