### PR TITLE
Add upload timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Client secret can also be provided by setting an environment variable. The envir
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE` (Deprecated. Please favor `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`)
 
+##### --upload-timeout
+
+The maximum time in seconds to wait for the extension package to be uploaded. If the extension package has not been uploaded within this time, the command will exit with an error. The default value is 50 seconds.
+
 ##### --verbose
 
 Logs additional information useful for debugging.

--- a/bin/__tests__/monitorStatus.test.js
+++ b/bin/__tests__/monitorStatus.test.js
@@ -84,7 +84,7 @@ describe('monitorStatus', () => {
     let errorMessage;
 
     try {
-      await monitorStatus(envConfig, accessToken, extensionPackageId, {});
+      await monitorStatus(envConfig, accessToken, extensionPackageId, {uploadTimeout: 50});
     } catch (error) {
       errorMessage = error.message;
     }

--- a/bin/index.js
+++ b/bin/index.js
@@ -38,6 +38,12 @@ const argv = require('yargs/yargs')(hideBin(process.argv))
       type: 'string',
       describe: 'For authentication using an Adobe I/O integration. Your client secret. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io). Optionally, rather than passing the client secret as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT, REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE, REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE, REACTOR_IO_INTEGRATION_CLIENT_SECRET. REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE is deprecated in favor of REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE and will be removed in the future.'
     },
+    'upload-timeout': {
+      type: 'number',
+      describe:
+        'The maximum time in seconds to wait for the extension package to be uploaded. If the extension package has not been uploaded within this time, the command will exit with an error.',
+      default: 50
+    },
     environment: {
       type: 'string',
       describe: 'The environment to which the extension packaqe should be uploaded (for Adobe internal use only).',

--- a/bin/monitorStatus.js
+++ b/bin/monitorStatus.js
@@ -18,8 +18,6 @@ const handleResponseError = require('./handleResponseError');
 const getMessageFromReactorError = require('./getMessageFromReactorError');
 const logVerboseHeader = require('./logVerboseHeader');
 
-const MAX_RETRIES = 50;
-
 const requestStatus = async (
   envConfig,
   accessToken,
@@ -28,8 +26,10 @@ const requestStatus = async (
   spinner,
   retries = 0
 ) => {
-  if (retries >= MAX_RETRIES) {
-    throw new Error('The extension package failed to be processed within the expected timeframe.');
+  if (retries >= argv.uploadTimeout) {
+    throw new Error(
+      'The extension package failed to be processed within the expected timeframe.'
+    );
   }
 
   if (argv.verbose) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-uploader",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-uploader",
-      "version": "5.1.2",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/jwt-auth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-uploader",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "description": "Command line tool for uploading Tags extensions.",
   "author": {
     "name": "Adobe Systems",


### PR DESCRIPTION
<!-- Copyright 2020 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a configurable parameter called upload-timeout. The `reactor-uploader` script will exit with an error if an extension is not processed by the backend in a timeframe of 50 seconds.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The `reactor-extension-alloy` project is using `reactor-uploader` in order to push BETA extensions automatically to an ORG for every commit merged into main. `reactor-extension-alloy` is taking more than 50 seconds to be processed by the backend. We need this parameter in order for our CI actions to no longer fail.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
